### PR TITLE
build: Add hatch-vcs plugin for auto versioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,6 @@ target/
 
 # Hydra logs
 outputs
+
+# Local Package
+version.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [project]
 name = "planetsca"
-version = "0.3.4.2"
+dynamic = ["version"]
 readme = "README.md"
 description = "Mapping snow covered areas (SCA) from high-resolution PlanetScope images using Random Forest model"
 dependencies = [
@@ -50,6 +50,15 @@ exclude = [
   "/demo",
   "/additional_assets"
 ]
+
+[tool.hatch.version]
+source = "vcs"
+
+[tool.hatch.build.hooks.vcs]
+version-file = "src/planetsca/version.py"
+
+[tool.hatch.version.raw-options]
+local_scheme = "no-local-version"
 
 [tool.ruff]
 # Exclude a variety of commonly ignored directories.


### PR DESCRIPTION
This PR adds auto versioning. This means that version now goes off the version control system, which in this case is git. It will grab version number based on the given git tag during release. Otherwise, it will become `x.x.x.devX` version